### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/philipcristiano/docker-prefetch-image/compare/v0.1.2...v0.1.3) - 2023-12-05
+
+### Other
+- Attempt to push semver tagged docker images
+
 ## [0.1.2](https://github.com/philipcristiano/docker-prefetch-image/compare/v0.1.1...v0.1.2) - 2023-12-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "docker-prefetch-image"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-prefetch-image"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Pull Docker images to a Docker daemon via a configuration file"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `docker-prefetch-image`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/philipcristiano/docker-prefetch-image/compare/v0.1.2...v0.1.3) - 2023-12-05

### Other
- Attempt to push semver tagged docker images
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).