### PR TITLE
feat: Fetch alternatives and tag as the desired image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "serde_json",
  "service_conventions",
  "signal-hook",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1.37.0", features = ["full"]}
 toml = "0.8.12"
 tracing = "0.1.40"
 
-
 url = "2.5.0"
 signal-hook = "0.3.17"
 service_conventions = "0.0.12"
+thiserror = "1.0.58"

--- a/README.md
+++ b/README.md
@@ -25,9 +25,3 @@ docker-prefetch-image -c docker-prefect-image.toml.example
 ```
 
 See [example_job](example_job.hcl) for an example of deploying in Nomad.
-
-
-## Still Todo
-
-* "Alternative" location to download an image.
-  * Pull from a remote repository, tag it as the local repository. This would allow a fallback to a remote repository but using the image as if it were the local repository.

--- a/docker-prefetch-image.toml.example
+++ b/docker-prefetch-image.toml.example
@@ -1,2 +1,9 @@
 [[image]]
 image = "busybox:latest"
+
+[[image]]
+image = "miniflux/miniflux:latest"
+alternative_images = [
+  "ghcr.io/miniflux/miniflux:latest",
+  "quay.io/miniflux/miniflux:latest",
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@ use futures::executor::block_on;
 use serde::Deserialize;
 use std::fs;
 use std::str;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use tokio::time::{sleep, Duration};
 use futures::StreamExt;
+use thiserror::Error;
+use tokio::time::{sleep, Duration};
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -30,8 +31,9 @@ struct AppConfig {
 #[derive(Clone, Debug, Deserialize)]
 struct ImageConfig {
     image: String,
+    #[serde(default)]
+    alternative_images: Vec<String>,
 }
-
 
 #[tokio::main]
 async fn main() {
@@ -45,8 +47,7 @@ async fn main() {
 
     // Start connections
     tracing::info!("connecting to {}", args.docker_socket);
-    let docker =
-        docker_api::Docker::new(args.docker_socket).unwrap();
+    let docker = docker_api::Docker::new(args.docker_socket).unwrap();
 
     list_images(&docker);
 
@@ -54,10 +55,10 @@ async fn main() {
 
     while !term.load(Ordering::Relaxed) {
         for image in app_config.image.clone() {
-            let url = image.image.clone();
-            pull_image(&docker, url);
-
-        };
+            if pull_image_or_alternatves(&docker, &image).is_err() {
+                tracing::error!("Failed to pull image or alternatives");
+            };
+        }
 
         tracing::info!("Sleeping for {:?}", sleep_duration);
         sleep(sleep_duration).await;
@@ -67,13 +68,13 @@ async fn main() {
 fn read_app_config(path: String) -> AppConfig {
     let config_file_error_msg = format!("Could not read config file {}", path);
     let config_file_contents = fs::read_to_string(path).expect(&config_file_error_msg);
-    let app_config: AppConfig = toml::from_str(&config_file_contents).expect("Problems parsing config file");
+    let app_config: AppConfig =
+        toml::from_str(&config_file_contents).expect("Problems parsing config file");
 
     app_config
 }
 
 fn list_images(docker: &docker_api::Docker) {
-
     let imagesf = block_on(docker.images().list(&Default::default()));
     match imagesf {
         Ok(images) => {
@@ -83,29 +84,67 @@ fn list_images(docker: &docker_api::Docker) {
         }
         Err(e) => eprintln!("Something bad happened! {e}"),
     }
-
 }
 
-fn pull_image(docker: &docker_api::Docker, url: String) {
+#[derive(Error, Debug)]
+pub enum PullError {
+    #[error(transparent)]
+    PullError(#[from] docker_api::Error),
+}
+
+fn pull_image_or_alternatves(
+    docker: &docker_api::Docker,
+    image_config: &ImageConfig,
+) -> Result<(), PullError> {
+    let image_url = image_config.image.clone();
+    let pull_result = pull_image(&docker, image_url.clone());
+    if pull_result.is_ok() {
+        return Ok(());
+    };
+    tracing::info!("Could not pull image {}", image_config.image);
+    for alternative in &image_config.alternative_images {
+        tracing::info!("Trying alternative image {}", alternative);
+        if pull_image(&docker, alternative.clone()).is_ok() {
+            tracing::info!("Tagging alternative {}", alternative);
+            if tag_image_as(&docker, &alternative, &image_url).is_ok() {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn pull_image(docker: &docker_api::Docker, url: String) -> Result<(), PullError> {
     tracing::info!("Pulling image {:?}", url);
     // let pull_opts = docker_api::opts::PullOptsBuilder::default().image(url).build();
-    let pull_opts = docker_api::opts::PullOpts::builder().image(url.clone()).tag("").build();
+    let pull_opts = docker_api::opts::PullOpts::builder()
+        .image(url.clone())
+        .tag("")
+        .build();
     tracing::info!("Opts {:?}", pull_opts);
     let dimages = docker.images();
     let mut pull = dimages.pull(&pull_opts);
     while let Some(v) = block_on(pull.next()) {
         match v {
             Ok(m) => {
-               tracing::debug!(
-                 image = url,
-                 "{:?}", m)
+                tracing::debug!(image = url, "{:?}", m)
             }
             Err(err) => {
-               tracing::error!(
-                 image = url,
-                 "{:?}", err
-               );
+                tracing::error!(image = url, "{:?}", err);
+                Err(err)?
             }
         }
-    };
+    }
+    return Ok(());
+}
+
+fn tag_image_as(
+    docker: &docker_api::Docker,
+    image: &String,
+    new_tag: &String,
+) -> Result<(), docker_api::Error> {
+    let docker_image = docker_api::Image::new(docker.clone(), image.clone());
+    let tag_opts = docker_api::opts::TagOpts::builder().repo(new_tag).build();
+    block_on(docker_image.tag(&tag_opts))?;
+    return Ok(());
 }


### PR DESCRIPTION
This will handle a failed pull and attempt to pull the image from an alternative location. This can be useful if a repository is not yet setup/down in such cases of bootstrapping or operational problems