### PR TITLE
chore: Clean up automerge dependabot action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,13 +8,6 @@ on:
 
 jobs:
 
-  automerge_dependabot:
-    uses: "philipcristiano/workflows/.github/workflows/automerge_dependabot.yml@main"
-    with:
-      automerge: true
-    secrets:
-      WF_GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-
   check-for-cc:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This uses renovate and not dependabout, this action is no longer required